### PR TITLE
Don't show completion while typing in range

### DIFF
--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -19,10 +19,25 @@ local MODIFIER_REGEX = {
   vim.regex([=[verb\%[ose]\s*]=]),
   vim.regex([=[vert\%[ical]\s*]=]),
 }
+
+-- Matches (examples):
+-- 23
+-- -
+-- +23
+-- .
+-- $
+local line_address_regex = [=[\%(\$\|\.\|[-+]\d*\|\d\+\)\?]=]
+
 local COUNT_RANGE_REGEX = {
-  vim.regex([=[\%(\d\+\|\$\),\%(\d\+\|\$\)\s*]=]),
   vim.regex([=['<,'>\s*]=]),
-  vim.regex([=[\%(\d\+\|\$\)\s*]=]),
+  -- The regex below should match these examples:
+  -- 4
+  -- 5,
+  -- 6,7
+  -- -6,+7
+  -- +6,$
+  -- -6,-3t.
+  vim.regex(line_address_regex .. [=[,\?]=] .. line_address_regex .. [=[\s*[tmyd]\?\s*]=] .. line_address_regex),
 }
 
 local definitions = {


### PR DESCRIPTION
I use relative numbers to copy blocks of text. E.g. `:-12,-10t.` copies lines from 12 lines up to 10 lines to the line under cursor. The problem is that as soon as type in `,` I get this:

![image](https://user-images.githubusercontent.com/23721/166115516-336e9644-9640-4866-bc19-3088e8a9360a.png)

This pr addresses that problem.

Related to #45