### PR TITLE
Remove constraint of working only in command mode

### DIFF
--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -98,10 +98,6 @@ source.get_trigger_characters = function()
   return { ' ', '.', '#', '-' }
 end
 
-source.is_available = function()
-  return vim.api.nvim_get_mode().mode == 'c'
-end
-
 source.complete = function(self, params, callback)
   local offset = 0
   local ctype = ''


### PR DESCRIPTION
The hard constraint of being available only in command mode is limiting the use of this source where end user believes it's needed.
For example it used to be not available in command line window (`:q`).