### PR TITLE
Escape dollars in names to prevent env-var expansion

### DIFF
--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -135,6 +135,7 @@ local definitions = {
       local escaped = cmdline:gsub([[\\]], [[\\\\]]);
       for _, word_or_item in ipairs(vim.fn.getcompletion(escaped, 'cmdline')) do
         local word = type(word_or_item) == 'string' and word_or_item or word_or_item.word
+        word = vim.fn.fnameescape(word) -- escape words to prevent expansions in cmdline
         local item = { label = word }
         table.insert(items, item)
         if is_option_name_completion and is_boolean_option(word) then


### PR DESCRIPTION
Dollars in filenames need to be escaped so they aren't interpreted as variables for expansion

<img width="322" alt="image" src="https://github.com/user-attachments/assets/dd8149ac-01f2-423e-ae5a-67dd5cb0bb84">
<img width="224" alt="image" src="https://github.com/user-attachments/assets/7f65ea14-f996-4902-b121-49d41ad92524">

Having `$` in filenames is something that is common in Remix ([dynamic segments](https://remix.run/docs/en/main/file-conventions/routes#dynamic-segments))