### PR TITLE
Changed fixed_input to accomodate --foo=bar

### DIFF
--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -123,6 +123,12 @@ local definitions = {
       local fixed_input
       do
         local suffix_pos = vim.regex([[\h\w*$]]):match_str(arglead)
+        local match = (string.match(arglead, "(%-%-[%w%-]+=)"))
+
+        if match then
+          arglead = match
+        end
+
         fixed_input = string.sub(arglead, 1, suffix_pos or #arglead)
       end
 


### PR DESCRIPTION
Some completion results include a fixed, static input along with dynamic contents. For example, `--foo=bar`. `--foo=` is the fixed part but `bar` is user input and is no longer part of `fixed_input`'s computation.