### PR TITLE
fix: escape special chars in filenames

### DIFF
--- a/lua/cmp_cmdline/init.lua
+++ b/lua/cmp_cmdline/init.lua
@@ -130,18 +130,30 @@ local definitions = {
       -- cmp-cmdline corrects `no` prefix for option name.
       local is_option_name_completion = OPTION_NAME_COMPLETION_REGEX:match_str(cmdline) ~= nil
 
+      local compltype = vim.fn.getcmdcompltype()
+      local is_path_completion = compltype == 'dir'
+          or compltype == 'file'
+          or compltype == 'file_in_path'
+          or compltype == 'runtime'
+
       --- create items.
       local items = {}
       local escaped = cmdline:gsub([[\\]], [[\\\\]]);
-      for _, word_or_item in ipairs(vim.fn.getcompletion(escaped, 'cmdline')) do
-        local word = type(word_or_item) == 'string' and word_or_item or word_or_item.word
-        local item = { label = word }
-        table.insert(items, item)
-        if is_option_name_completion and is_boolean_option(word) then
-          table.insert(items, vim.tbl_deep_extend('force', {}, item, {
-            label = 'no' .. word,
-            filterText = word,
-          }))
+      local completion_ok, completion = pcall(vim.fn.getcompletion, escaped, 'cmdline')
+      if completion_ok then
+        for _, word_or_item in ipairs(completion) do
+          local word = type(word_or_item) == 'string' and word_or_item or word_or_item.word
+          if is_path_completion then
+            word = vim.fn.fnameescape(word)
+          end
+          local item = { label = word }
+          table.insert(items, item)
+          if is_option_name_completion and is_boolean_option(word) then
+            table.insert(items, vim.tbl_deep_extend('force', {}, item, {
+              label = 'no' .. word,
+              filterText = word,
+            }))
+          end
         end
       end
 


### PR DESCRIPTION
This PR escape special chars in filenames, like the native cmdline completion do.

Consider we have a file with special char `%` in its filename, the current implementation will not escape it:

![image](https://github.com/user-attachments/assets/69b93378-2765-4790-9c29-ffc69f69736e)

Pressing `<CR>` with make neovim expand `%` to current buffer name.

The native cmdline completion properly escapes it:

![image](https://github.com/user-attachments/assets/fda452c0-35e3-4cf2-a9b4-4f55cc605d6d)

The PR fixes the issue:

![image](https://github.com/user-attachments/assets/50b78a31-727a-40e6-afc0-d2a3a5ed1e80)
